### PR TITLE
Identifiers should start with capital letters

### DIFF
--- a/src/java.grammar
+++ b/src/java.grammar
@@ -684,7 +684,7 @@ commaSepTrailing<expr> { (expr ("," expr?)*)? }
 
   Asterisk { "*" }
 
-  identifier { $[a-z_$] $[a-zA-Z0-9_$]* }
+  identifier { $[a-zA-Z_$] $[a-zA-Z0-9_$]* }
 
   capitalIdentifier { $[A-Z] $[a-zA-Z0-9_$]* }
 


### PR DESCRIPTION
See https://github.com/lezer-parser/java/issues/1 and https://docs.oracle.com/javase/specs/jls/se15/html/jls-3.html#jls-Identifier