### PR TITLE
Fix syntax highlighting for float literals

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -11,7 +11,7 @@ export const javaHighlighting = styleTags({
   ["requires exports opens uses provides public private protected static transitive abstract final " +
    "strictfp synchronized native transient volatile throws"]: t.modifier,
   IntegerLiteral: t.integer,
-  FloatLiteral: t.float,
+  FloatingPointLiteral: t.float,
   "StringLiteral TextBlock": t.string,
   CharacterLiteral: t.character,
   LineComment: t.lineComment,


### PR DESCRIPTION
I _believe_ this is a bug (but please correct me if I'm wrong): I noticed that the Lezer parser for Java marks floats as [`FloatingPointLiteral`](https://github.com/lezer-parser/java/blob/0f8b487d879b9d9c89ac68a344ae18ab78839579/src/java.grammar#L677)s but the syntax highlighting spec refers to them as `FloatLiteral`s.

This results in floats not having proper syntax highlighting in Java. This PR addresses this by fixing the corresponding key in the highlight spec and standardizing on `FloatingPointLiteral`. I've confirmed that `yarn build` and `yarn test` still passes as expected.