### PR TITLE
Fix syntax highlighting for "var" keyword

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -17,7 +17,7 @@ export const javaHighlighting = styleTags({
   LineComment: t.lineComment,
   BlockComment: t.blockComment,
   BooleanLiteral: t.bool,
-  PrimitiveType: t.standard(t.typeName),
+  "PrimitiveType var": t.standard(t.typeName),
   TypeName: t.typeName,
   Identifier: t.variableName,
   "MethodName/Identifier": t.function(t.variableName),

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -5,7 +5,7 @@ export const javaHighlighting = styleTags({
     instanceof: t.operatorKeyword,
   this: t.self,
   "new super assert open to with void": t.keyword,
-  "class interface extends implements enum": t.definitionKeyword,
+  "class interface extends implements enum var": t.definitionKeyword,
   "module package import": t.moduleKeyword,
   "switch while for if else case default do break continue return try catch finally throw": t.controlKeyword,
   ["requires exports opens uses provides public private protected static transitive abstract final " +

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -17,7 +17,7 @@ export const javaHighlighting = styleTags({
   LineComment: t.lineComment,
   BlockComment: t.blockComment,
   BooleanLiteral: t.bool,
-  "PrimitiveType var": t.standard(t.typeName),
+  PrimitiveType: t.standard(t.typeName),
   TypeName: t.typeName,
   Identifier: t.variableName,
   "MethodName/Identifier": t.function(t.variableName),

--- a/src/java.grammar
+++ b/src/java.grammar
@@ -558,6 +558,7 @@ unannotatedType {
 
 simpleType {
   kw<"void"> |
+  ckw<"var"> |
   @specialize[@name=PrimitiveType]<identifier, "byte" | "short" | "int" | "long" | "char" | "float" | "double" | "boolean"> |
   TypeName |
   ScopedTypeName |
@@ -622,7 +623,7 @@ Throws {
 }
 
 LocalVariableDeclaration {
-  Modifiers? (ckw<"var"> | unannotatedType) commaSep1<VariableDeclarator> ";"
+  Modifiers? unannotatedType commaSep1<VariableDeclarator> ";"
 }
 
 MethodDeclaration {

--- a/src/java.grammar
+++ b/src/java.grammar
@@ -558,7 +558,6 @@ unannotatedType {
 
 simpleType {
   kw<"void"> |
-  ckw<"var"> |
   @specialize[@name=PrimitiveType]<identifier, "byte" | "short" | "int" | "long" | "char" | "float" | "double" | "boolean"> |
   TypeName |
   ScopedTypeName |
@@ -623,7 +622,7 @@ Throws {
 }
 
 LocalVariableDeclaration {
-  Modifiers? unannotatedType commaSep1<VariableDeclarator> ";"
+  Modifiers? (ckw<"var"> | unannotatedType) commaSep1<VariableDeclarator> ";"
 }
 
 MethodDeclaration {


### PR DESCRIPTION
I discovered that the newly introduced "var" keyword does not have proper syntax highlighting in Java despite the grammar [supporting it](https://github.com/lezer-parser/java/commit/d35006b7e72645d5e17c9b241caff85d2a67691e).

It seems that it's not being highlighted as a `typeName` like the rest of the type names (e.g. `int`, `long`, etc) are. I think adding it to the list of `simpleTypes` should do the trick. We can also remove the union type in the local variable declaration since that would be made redundant. I'm new to Lezer grammars so please let me know if something looks off!