### PR TITLE
Fix parsing of multiple consecutive underscore in digits

### DIFF
--- a/src/java.grammar
+++ b/src/java.grammar
@@ -647,7 +647,7 @@ commaSepTrailing<expr> { (expr ("," expr?)*)? }
   }
 
   digits {
-    $[0-9]+ ("_" $[0-9]+)*
+    $[0-9]+ ("_"* $[0-9]+)*
   }
 
   hexDigits {

--- a/src/java.grammar
+++ b/src/java.grammar
@@ -647,7 +647,7 @@ commaSepTrailing<expr> { (expr ("," expr?)*)? }
   }
 
   digits {
-    $[0-9]+ ("_"* $[0-9]+)*
+    $[0-9]+ ("_"+ $[0-9]+)*
   }
 
   hexDigits {


### PR DESCRIPTION
In Java, having multiple underscores in between digits is valid syntax. e.g.

```java
int num = 123____456;
```

but it seems that is not being properly highlighted in CodeMirror. This PR attempts to address that by modifying the grammar to permit an arbitrary number of `_` in between numbers when parsing digits. Let me know if this looks right.